### PR TITLE
Modified transposition table

### DIFF
--- a/2048.cpp
+++ b/2048.cpp
@@ -12,13 +12,13 @@
 #include "config.h"
 #if defined(HAVE_UNORDERED_MAP)
     #include <unordered_map>
-    typedef std::unordered_map<board_t, float> trans_table_t;
+    typedef std::unordered_map<board_t, trans_table_entry_t> trans_table_t;
 #elif defined(HAVE_TR1_UNORDERED_MAP)
     #include <tr1/unordered_map>
-    typedef std::tr1::unordered_map<board_t, float> trans_table_t;
+    typedef std::tr1::unordered_map<board_t, trans_table_entry_t> trans_table_t;
 #else
     #include <map>
-    typedef std::map<board_t, float> trans_table_t;
+    typedef std::map<board_t, trans_table_entry_t> trans_table_t;
 #endif
 
 /* MSVC compatibility: undefine max and min macros */
@@ -310,19 +310,28 @@ static float score_board(board_t board) {
 // cprob: cumulative probability
 // don't recurse into a node with a cprob less than this threshold
 static const float CPROB_THRESH_BASE = 0.0001f;
-static const int CACHE_DEPTH_LIMIT  = 6;
+static const int CACHE_DEPTH_LIMIT  = 15;
 
 static float score_tilechoose_node(eval_state &state, board_t board, float cprob) {
     if (cprob < CPROB_THRESH_BASE || state.curdepth >= state.depth_limit) {
         state.maxdepth = std::max(state.curdepth, state.maxdepth);
         return score_heur_board(board);
     }
-
     if (state.curdepth < CACHE_DEPTH_LIMIT) {
         const trans_table_t::iterator &i = state.trans_table.find(board);
         if (i != state.trans_table.end()) {
-            state.cachehits++;
-            return i->second;
+			trans_table_entry_t entry = i->second;
+			/*
+			return heuristic from transposition table only if it means that
+			the node will have been evaluated to a minimum depth of state.depth_limit.
+			This will result in slightly fewer cache hits, but should not impact the
+			strength of the ai negatively.
+			*/
+			if(entry.depth <= state.curdepth)
+			{
+                state.cachehits++;
+				return entry.heuristic;
+			}
         }
     }
 
@@ -343,7 +352,8 @@ static float score_tilechoose_node(eval_state &state, board_t board, float cprob
     res = res / num_open;
 
     if (state.curdepth < CACHE_DEPTH_LIMIT) {
-        state.trans_table[board] = res;
+		trans_table_entry_t entry = {state.curdepth, res};
+		state.trans_table[board] = entry;
     }
 
     return res;

--- a/2048.cpp
+++ b/2048.cpp
@@ -37,32 +37,32 @@
 //   cdef       37bf
 static inline board_t transpose(board_t x)
 {
-	board_t a1 = x & 0xF0F00F0FF0F00F0FULL;
-	board_t a2 = x & 0x0000F0F00000F0F0ULL;
-	board_t a3 = x & 0x0F0F00000F0F0000ULL;
-	board_t a = a1 | (a2 << 12) | (a3 >> 12);
-	board_t b1 = a & 0xFF00FF0000FF00FFULL;
-	board_t b2 = a & 0x00FF00FF00000000ULL;
-	board_t b3 = a & 0x00000000FF00FF00ULL;
-	return b1 | (b2 >> 24) | (b3 << 24);
+    board_t a1 = x & 0xF0F00F0FF0F00F0FULL;
+    board_t a2 = x & 0x0000F0F00000F0F0ULL;
+    board_t a3 = x & 0x0F0F00000F0F0000ULL;
+    board_t a = a1 | (a2 << 12) | (a3 >> 12);
+    board_t b1 = a & 0xFF00FF0000FF00FFULL;
+    board_t b2 = a & 0x00FF00FF00000000ULL;
+    board_t b3 = a & 0x00000000FF00FF00ULL;
+    return b1 | (b2 >> 24) | (b3 << 24);
 }
 
 // Count the number of empty positions (= zero nibbles) in a board.
 // Precondition: the board cannot be fully empty.
 static int count_empty(board_t x)
 {
-	x |= (x >> 2) & 0x3333333333333333ULL;
-	x |= (x >> 1);
-	x = ~x & 0x1111111111111111ULL;
-	// At this point each nibble is:
-	//  0 if the original nibble was non-zero
-	//  1 if the original nibble was zero
-	// Next sum them all
-	x += x >> 32;
-	x += x >> 16;
-	x += x >>  8;
-	x += x >>  4; // this can overflow to the next nibble if there were 16 empty positions
-	return x & 0xf;
+    x |= (x >> 2) & 0x3333333333333333ULL;
+    x |= (x >> 1);
+    x = ~x & 0x1111111111111111ULL;
+    // At this point each nibble is:
+    //  0 if the original nibble was non-zero
+    //  1 if the original nibble was zero
+    // Next sum them all
+    x += x >> 32;
+    x += x >> 16;
+    x += x >>  8;
+    x += x >>  4; // this can overflow to the next nibble if there were 16 empty positions
+    return x & 0xf;
 }
 
 /* We can perform state lookups one row at a time by using arrays with 65536 entries. */
@@ -320,18 +320,18 @@ static float score_tilechoose_node(eval_state &state, board_t board, float cprob
     if (state.curdepth < CACHE_DEPTH_LIMIT) {
         const trans_table_t::iterator &i = state.trans_table.find(board);
         if (i != state.trans_table.end()) {
-			trans_table_entry_t entry = i->second;
-			/*
-			return heuristic from transposition table only if it means that
-			the node will have been evaluated to a minimum depth of state.depth_limit.
-			This will result in slightly fewer cache hits, but should not impact the
-			strength of the ai negatively.
-			*/
-			if(entry.depth <= state.curdepth)
-			{
+            trans_table_entry_t entry = i->second;
+            /*
+            return heuristic from transposition table only if it means that
+            the node will have been evaluated to a minimum depth of state.depth_limit.
+            This will result in slightly fewer cache hits, but should not impact the
+            strength of the ai negatively.
+            */
+            if(entry.depth <= state.curdepth)
+            {
                 state.cachehits++;
-				return entry.heuristic;
-			}
+                return entry.heuristic;
+            }
         }
     }
 
@@ -352,8 +352,8 @@ static float score_tilechoose_node(eval_state &state, board_t board, float cprob
     res = res / num_open;
 
     if (state.curdepth < CACHE_DEPTH_LIMIT) {
-		trans_table_entry_t entry = {state.curdepth, res};
-		state.trans_table[board] = entry;
+        trans_table_entry_t entry = {state.curdepth, res};
+        state.trans_table[board] = entry;
     }
 
     return res;

--- a/2048.h
+++ b/2048.h
@@ -15,6 +15,12 @@
 typedef uint64_t board_t;
 typedef uint16_t row_t;
 
+//store the depth at which the heuristic was recorded as well as the actual heuristic
+struct trans_table_entry_t{
+	uint8_t depth;
+	float heuristic;
+};
+
 static const board_t ROW_MASK = 0xFFFFULL;
 static const board_t COL_MASK = 0x000F000F000F000FULL;
 

--- a/2048.h
+++ b/2048.h
@@ -17,8 +17,8 @@ typedef uint16_t row_t;
 
 //store the depth at which the heuristic was recorded as well as the actual heuristic
 struct trans_table_entry_t{
-	uint8_t depth;
-	float heuristic;
+    uint8_t depth;
+    float heuristic;
 };
 
 static const board_t ROW_MASK = 0xFFFFULL;


### PR DESCRIPTION
The current implementation of the transposition table resulted in nodes that 
were evaluated to a depth either lower or higher than the depth_limit. 
This change eliminates cache hits which resulted in a node evaluated to a depth
less than depth_limit.

Technically this means that there are fewer cache hits than before, therefore it
plays slightly slower when there are still small numbers on the board. However,
since this allows the use of a deeper cache without negative effects to ai
strength, when coupled with Petr Moravek's adaptive search depth limit, it
results in a significant speedup when there are large numbers on the board
(ex. in cases just before a large number is reached).

I also increased CACHE_DEPTH_LIMIT to 15 which, since the current implementation
results in a maximum depth_limit of 14, means that the cache will be used in all
levels of the search. The program is obviously more memory hungry now. During
testing I saw spikes up to about 60MB of memory usage just before reaching a
32768 tile, which isn't really that bad. In my opinion memory is cheap, but time
is money haha.

I ran a test by fixing the search depth to 3 (I disabled the adaptive search
depth limit) and then running 100 games each of the following 3 variants:
(A) CACHE_DEPTH_LIMIT set to 0
(B) CACHE_DEPTH_LIMIT set to 3 using the old transposition table
(C) CACHE_DEPTH_LIMIT set to 3 using the new transposition table

I then checked the average score of the 100 games. My results were as follows:
(A) 132341
(B) 129610
(C) 134610

I ran the test several times and every time the results were B < A < C. It is
evident that the old implementation was negatively affecting the strength of
the AI, while the new one actually improves it a little bit.

Letting the program run until it reached the 32768 tile, I noticed
approximately a 50% improvement in average speed throughout the game.