### PR TITLE
fix error: non-constant-expression narrowing

### DIFF
--- a/2048.cpp
+++ b/2048.cpp
@@ -352,7 +352,7 @@ static float score_tilechoose_node(eval_state &state, board_t board, float cprob
     res = res / num_open;
 
     if (state.curdepth < CACHE_DEPTH_LIMIT) {
-        trans_table_entry_t entry = {state.curdepth, res};
+        trans_table_entry_t entry = {static_cast<uint8_t>(state.curdepth), res};
         state.trans_table[board] = entry;
     }
 


### PR DESCRIPTION
compiling on OSX 10.9 results in a compile error.

error reported by g++:

```
2048.cpp:355:38: error: non-constant-expression cannot be narrowed from type 'int' to 'uint8_t'
      (aka 'unsigned char') in initializer list [-Wc++11-narrowing]
        trans_table_entry_t entry = {state.curdepth, res};
                                     ^~~~~~~~~~~~~~
2048.cpp:355:38: note: override this message by inserting an explicit cast
        trans_table_entry_t entry = {state.curdepth, res};
                                     ^~~~~~~~~~~~~~
                                     static_cast<uint8_t>( )
```

g++ --version output:
```
Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 6.0 (clang-600.0.57) (based on LLVM 3.5svn)
Target: x86_64-apple-darwin13.4.0
Thread model: posix
```